### PR TITLE
Ensure backwards compatibilty for change in zerok/jiravars#9

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@ issues is exported as a Gauge to Prometheus.
 ## Configuration
 
 The configuration is rather minimal: All you need are some JIRA credentials and
-the metrics that you want to collect. The JIRA password needs to be passed via environment variable `JIRA_PASSWORD`.
+the metrics that you want to collect. The JIRA password can optonally be passed 
+via environment variable `JIRA_PASSWORD`.
 
 Sample configuration:
 
 ```
 baseURL: https://jira.company.net
 login: "{{ vault "secret/accounts/work/me" "login"}}"
+password: "{{ vault "secret/accounts/work/me" "password"}}"
 metrics:
     - name: taa_backlog_size
       help: Number of items inside our backlog

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ type metricConfiguration struct {
 type configuration struct {
 	BaseURL     string                `yaml:"baseURL"`
 	Login       string                `yaml:"login"`
-	Password    string                `yaml:"-"`
+	Password    string                `yaml:"password"`
 	Metrics     []metricConfiguration `yaml:"metrics"`
 	HTTPHeaders map[string]string     `yaml:"httpHeaders"`
 }
@@ -175,9 +175,12 @@ func main() {
 		log.WithError(err).Fatalf("Failed to load config from %s", configFile)
 	}
 
-	cfg.Password = os.Getenv("JIRA_PASSWORD")
 	if cfg.Password == "" {
-		log.Fatal("Please specify a JIRA_PASSWORD via environment variable")
+		cfg.Password = os.Getenv("JIRA_PASSWORD")
+	}
+
+	if cfg.Password == "" {
+		log.Fatal("Please specify a jira password via configuration or JIRA_PASSWORD environment variable")
 	}
 
 	if err := setupGauges(cfg.Metrics); err != nil {


### PR DESCRIPTION
The change being done in zerok/jiravars#9 breaks backwards compatibilty. This keeps the previous approach and make passing the password via environment variable possible additionally.
